### PR TITLE
API-7188-java16-upgrade

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM vasdvp/health-apis-dev-tools:mvn-3.6-jdk-14
+FROM vasdvp/health-apis-dev-tools:mvn-3.8-jdk-16
 
 ARG flyway_version=7.0.4
 

--- a/minimart-manager/.mvn/jvm.config
+++ b/minimart-manager/.mvn/jvm.config
@@ -1,0 +1,14 @@
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED
+--add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-opens=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+--add-opens=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+--add-opens=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-opens=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+--add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/minimart-manager/pom.xml
+++ b/minimart-manager/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>gov.va.api.health</groupId>
     <artifactId>test-starter</artifactId>
-    <version>8.0.2</version>
+    <version>8.0.7</version>
     <relativePath/>
   </parent>
   <artifactId>minimart-manager</artifactId>

--- a/minimart-manager/pom.xml
+++ b/minimart-manager/pom.xml
@@ -4,20 +4,20 @@
   <parent>
     <groupId>gov.va.api.health</groupId>
     <artifactId>test-starter</artifactId>
-    <version>7.0.5</version>
+    <version>8.0.2</version>
     <relativePath/>
   </parent>
   <artifactId>minimart-manager</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <properties>
-    <datamart-starter.version>2.0.1</datamart-starter.version>
+    <datamart-starter.version>3.0.0</datamart-starter.version>
     <apache-csv.version>1.8</apache-csv.version>
-    <data-query.version>3.0.179</data-query.version>
+    <data-query.version>3.0.185</data-query.version>
     <fall-risk.version>2.0.0</fall-risk.version>
     <git.allowedBranchNames><![CDATA[^(dependabot/.*|staging_lab|lab|PR-[0-9]+|(.*/)?[A-Z]{2,10}-[0-9]+-.*)$]]></git.allowedBranchNames>
     <javafaker.version>1.0.2</javafaker.version>
-    <vista-fhir-query.version>0.0.20</vista-fhir-query.version>
+    <vista-fhir-query.version>1.0.0</vista-fhir-query.version>
   </properties>
   <dependencies>
     <dependency>


### PR DESCRIPTION
# [API-7188](https://vajira.max.gov/browse/API-7188)
I think this should be good. It's using the dq and vfq java 16 versions (sans dq with updated dependencies though).